### PR TITLE
integrate https redirection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,7 @@ module.exports = function (grunt) {
           ]
         },
         options: {
+          https: true,
           server: {
             baseDir: [
               '.jekyll',
@@ -81,6 +82,7 @@ module.exports = function (grunt) {
       },
       dist: {
         options: {
+          https: true,
           server: {
             baseDir: '<%= yeoman.dist %>',
             middleware: customMiddleware

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -8,6 +8,7 @@
     <meta name="keywords" content="{{ page.keywords }}">
     <!-- Place favicon.ico and apple-touch-icon(s) in the root directory -->
     <link rel="shortcut icon" href="../img/favicon.ico" />
+    <link rel="canonical" href="https://maidsafe.net/{{ page.path }}" />
     <link rel="icon" property='stylesheet' type="image/ico" href="../img/favicon.ico" />
 
     {% include vendor.html %}

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,4 +1,7 @@
 /* global $: false, document: false, window: false */
+if (window.location.protocol !== 'https:') {
+  window.location = window.location.toString().replace(/^http:/, 'https:');
+}
 window.platform = null;
 window.OS = {
   'Mac OS': 'osx',


### PR DESCRIPTION
canonical link added for search engines to lookup for the secure link
javascript based redirection to https added

local development also uses https with self signed certificate.
