### PR TITLE
fix:typo_mobile_menu/correct spelling of aplha relase in mobile menu

### DIFF
--- a/app/_includes/html/header.html
+++ b/app/_includes/html/header.html
@@ -18,7 +18,7 @@
             <a href="#">More<span class="icn"></span></a>
             <a class="show-on-mob" href="#">Menu<span class="icn"></span></a>
             <ul class="nav-dropdown-b">
-              <li class="show-on-mob"><a href="./alpha.html">Alpha Relase</a></li>
+              <li class="show-on-mob"><a href="./alpha.html">Alpha Release</a></li>
               <li class="show-on-mob"><a href="./features.html">Features</a></li>
               <li class="show-on-mob"><a href="./safecoin.html">Safecoin</a></li>
               <li class="show-on-mob"><a href="./company.html">Company</a></li>


### PR DESCRIPTION
correct alpha release typo in mobile menu
