### PR TITLE
[ISSUE#85] Add link to first paragraph on homepage.

### DIFF
--- a/src/sass/shared/mixins.sass
+++ b/src/sass/shared/mixins.sass
@@ -6,7 +6,7 @@
     visibility: hidden
 
 =link()
-  text-decoration: underline
+  text-decoration: none
   color: $colr-grey
   font-weight: 600
 


### PR DESCRIPTION
🔖  [ISSUE#85] Should we link to the safenetwork.tech site on homepage
📌  [View Github Issue](https://github.com/maidsafe/maidsafe.net/issues/85)
___
 Changes to 2 files: home.js and mixins.sass.

✏️ **Summary of changes:**
home.js : added hyperlink to safenetwork.tech to the first paragraph which was re-written to reduce amount of text (which was also commented on so I thought I would address at the same time).  This meant padding the second paragraph "Intro to MaidSafe" with text ripped from summary.
___
