### PR TITLE
add Google custom map on about page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "core-js": "^3.6.4",
-    "html-react-parser": "^0.10.0",
+    "html-react-parser": "^0.10.2",
     "react-router-dom": "^5.1.2",
     "react-static": "^7.2.3",
     "react-static-plugin-react-router": "^7.2.3",

--- a/src/containers/about.js
+++ b/src/containers/about.js
@@ -101,7 +101,7 @@ class About extends React.Component {
 						</div>
 					</div>
 				</div>
-				<div className="page-banner safe-pod home-like company-page"></div>
+				<iframe className="page-banner safe-pod home-like company-page" src="https://www.google.com/maps/d/embed?mid=1jzIS5AfmX1Iq5zR3g9blpxWmbPGcbZh7" width="100%"></iframe>
 				<div id="what-drives-us" className="post-3">
 					<div className="post-3-cont">
 						<div className="post-3-cont-i">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4185,10 +4185,10 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
-html-react-parser@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.10.0.tgz#b0f3700831ce52e04013158982167c65292a418d"
-  integrity sha512-IDSoBgA8ZCiSoJSiumFMEUY1gsqEUeDDj8zUBGjET39RAC0aZpICp2F/doQFRqdLV0dCLLYHI7NabUara2nH1w==
+html-react-parser@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.10.2.tgz#b4a22b86809d00f71dad8370e2c18d37b7f48f70"
+  integrity sha512-CXAtbO0bMB8/TuMXgClap6C7SIcZvA5AP0inTJ93JZTryNiHUkCo5shsNBfegW9aqfdh1iWNGSy/dCku5vwdcw==
   dependencies:
     "@types/domhandler" "2.4.1"
     html-dom-parser "0.2.3"


### PR DESCRIPTION
This PR adds an embed version of [this custom Google map](https://www.google.com/maps/d/u/0/viewer?mid=1jzIS5AfmX1Iq5zR3g9blpxWmbPGcbZh7&ll=37.26846747530918%2C1.0278842999999824&z=3) on top of the map image on the About page.

Fixes #230 